### PR TITLE
Correct misinformation about this being an Arduino library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-RemoteSwitch library v2.3.0 (20121229) for Arduino 1.0
+RemoteSwitch library v2.3.0 (20121229) for Particle
 
 Originally authored by Randy Simons http://randysimons.nl/
 
@@ -6,5 +6,5 @@ Original repository: https://github.com/hjgode/homewatch/tree/master/arduino/lib
  
 **Compatible with Particle Photon.**
 
-This library provides an easy class for Arduino, to send and receive signals
+This library provides an easy class for Particle, to send and receive signals
 used by some common "old style" 433MHz remote control switches.


### PR DESCRIPTION
This is not an Arduino library. It is incompatible with the Arduino IDE or arduino-cli. This is a Particle library. Although Arduino libraries are compatible with Particle, Particle chose to make their system so that Particle libraries are usually not compatible with Arduino. Thus, calling this an "Arduino library" will only lead to confusion, frustration, and wasted time for Arduino users.

Please also remove the Arduino library claim from the repository description. You can do this by opening the home page of the repository and then clicking the "Edit" button at the top right of the page.